### PR TITLE
Hinesh's Comments via Freedcamp

### DIFF
--- a/Pencil 9/css/style.css
+++ b/Pencil 9/css/style.css
@@ -780,6 +780,17 @@ support for no js
 .font-white, .font-white a{
   color:#fff !important;
 }
+
+/* Pencil 9 - adding larger font for title, also increase font-weight */
+.norm-100-wide{
+	font-family: 'Open Sans',Arial,Helvetica,sans-serif;
+	font-size: 100px;
+	line-height: 100px;
+	font-weight: 400;
+  letter-spacing:24px;
+  color:#4b4e53;
+}
+
 .light-73-wide{
 	font-family: 'Lato',Arial,Helvetica,sans-serif;
 	font-size: 73px;
@@ -788,6 +799,7 @@ support for no js
   letter-spacing:24px;
   color:#4b4e53;
 }
+
 .light-72-wide{
 	font-family: 'Lato',Arial,Helvetica,sans-serif;
 	font-size: 72px;
@@ -873,6 +885,16 @@ support for no js
   letter-spacing:2px;
   color:#4b4e53;
 }
+/* Pencil 9 - Adding a larger regular font */
+.norm-32-wide{
+	font-family: 'Open Sans',Arial,Helvetica,sans-serif;
+	font-size: 32px;
+	line-height: 32px;
+	font-weight: 400;
+  letter-spacing:3px;
+  color:#4b4e53;
+}
+
 .norm-16-wide{
 	font-family: 'Lato',Arial,Helvetica,sans-serif;
 	font-size: 16px;

--- a/Pencil 9/index.html
+++ b/Pencil 9/index.html
@@ -200,7 +200,7 @@
 						<div id="rs-fullwidth" class="tp-banner dark-bg" >
 							<ul>	
 								<!-- SLIDE 1 -->
-								<li data-transition="zoomout" data-slotamount="1" data-masterspeed="1500" data-thumb="images/revo-slider/PEN9-thumb.png"  data-saveperformance="on"  data-title="PENCIL 9">
+								<li data-transition="zoomout" data-slotamount="1" data-masterspeed="1500" data-thumb="images/revo-slider/PEN9-thumb.png"  data-saveperformance="on"  data-title="Pencil 9">
 									<!-- MAIN IMAGE -->
 									 
 									<img src="images/revo-slider/dummy.png"  alt="Photo by Annie Spratt on Unsplash" data-lazyload="images/revo-slider/cool-office-space-contrast.jpg" data-bgposition="center top" data-bgfit="cover" data-bgrepeat="no-repeat">
@@ -209,8 +209,9 @@
 									
 									<!--PARALLAX & OPACITY container -->
 									<div class="rs-parallaxlevel-4 opacity-scroll2">
-										<!-- LAYER NR. 1 -->
-										<div class="tp-caption font-white light-73-wide sfb tp-resizeme"
+                    <!-- LAYER NR. 1 -->
+                    <!-- changed height from 73 -->
+										<div class="tp-caption font-white norm-100-wide sfb tp-resizeme"
 											data-x="center" 
                       data-hoffset="0" 
                       data-y="center" 
@@ -223,12 +224,12 @@
 											data-elementdelay="0.1"
 											data-endelementdelay="0.1"
                       style="z-index: 7; max-width: auto; max-height: auto; white-space: nowrap;">
-                      <span style="font-family: 'Open Sans'; letter-spacing: normal; font-weight: normal;">Pencil 9</span>
+                      <span style="font-family: 'Open Sans'; letter-spacing: normal;">Pencil 9</span>
 										</div>
 										
 										<!-- LAYER NR. 2 -->
 										<!--<div class="tp-caption font-white norm-16-wide tp-left sfb tp-resizeme hide-0-736"-->
-                    <div class="tp-caption font-white norm-16-wide tp-left sfb tp-resizeme"
+                    <div class="tp-caption font-white norm-32-wide tp-left sfb tp-resizeme"
 											data-x="center" 
                       data-hoffset="0" 
                       data-y="center" 
@@ -240,7 +241,7 @@
 											data-splitout="none"
 											data-elementdelay="0.1"
 											data-endelementdelay="0.1"
-											style="z-index: 9; max-width: auto; max-height: auto; white-space: nowrap; font-weight: normal !important;">PROVIDING SOLUTIONS TO AUTOMATE YOUR WORLD.
+											style="z-index: 9; max-width: auto; max-height: auto; white-space: nowrap;">Providing Solutions To Automate Your World
 										</div>
                     
                     <!-- LAYER NR. 3 -->
@@ -395,7 +396,7 @@
                     
                   <div class="col-md-12 col-sm-12 pb-10">
                     <div class="fes5-box wow fadeIn" data-wow-delay="200ms">
-                      <h3>YOUR GOALS & CHALLENGES</h3>
+                      <h3>Your Goals & Challenges</h3>
                       <p>Each firm has its own goals and challenges. You may be planning an organizational change or wanting to improve performance at a project level. No matter what your technology challenges and goals are, we pride ourselves in taking the time to really understand your organization's needs before developing a solution for you.</p>
                       <!-- Pencil 9 offers solutions that are easily scalable from office to enterprise. -->
                     </div>
@@ -406,7 +407,7 @@
                     
                   <div class="col-md-12 col-sm-12 pb-10">
                     <div class="fes5-box wow fadeIn" data-wow-delay="400ms">
-                      <h3>OUR SERVICES</h3>
+                      <h3>Our Services</h3>
                       <p>Pencil 9 provides consulting and software development services from the United States and United Kingdom within the Architecture, Engineering and Construction industry with a specialized focus on Information Management and Building Information Managment (BIM) disciplines working with Autodesk, Bentley, and CADWorx Plant Professional software platforms.</p>
                     </div>
                   </div>
@@ -445,7 +446,7 @@
                       
                     </div>
                   
-                    <h3>STRATEGIC</h3>
+                    <h3>Strategic</h3>
                     <p>We aim to become your long term trusted partner. We look forward to delivering strategic solutions that improve how your teams work.</p>
                   </div>
                 </div>
@@ -456,7 +457,7 @@
                     <div class="fes7-box-icon">
                       <div class="icon icon-basic-lightbulb"></div>
                     </div>
-                    <h3>WORK SMARTER</h3>
+                    <h3>Work Smarter</h3>
                     <p>Innovative solutions can often be found by maximizing the systems already in use at your firm.</p>
                   </div>
                 </div>
@@ -481,7 +482,7 @@
                     <div class="fes7-box-icon">
                       <div class="icon icon-basic-share"></div>
                     </div>
-                    <h3>CONNECT THE DOTS</h3>
+                    <h3>Connect the Dots</h3>
                     <p>Efficiencies can often be found through connecting multiple applications together and letting the data flow through them. Pencil 9 can develop the specific solutions to connect your data, reducing errors and vastly improving productivity.</p>
                   </div>
                 </div>
@@ -492,7 +493,7 @@
                     <div class="fes7-box-icon">
                       <div class="icon icon-arrows-circle-check"></div>
                     </div>
-                    <h3>REALISTIC</h3>
+                    <h3>Realistic</h3>
                     <p>Pencil 9 understands that in order to successfully implement solutions, they must be simple for end users with comfortable steps to transition.</p>
                   </div>
                 </div>
@@ -542,7 +543,7 @@
                       
                     </div>
                     
-                    <h3><span class="bold">IT INFRASTRUCTURE</span></h3>
+                    <h3><span class="bold">IT Infrastructure</span></h3>
                     <!--<p>STRATEGIES TO HELP TRANSFORM YOUR COMPANY</p>-->
                     <p>&nbsp</p>
                   </div>
@@ -559,12 +560,12 @@
 								  	<div class="fes4-box-icon">
                       <div class="icon icon-basic-pencil-ruler-pen"></div>
                     </div>
-                    <h3><span class="bold">PROJECT OR COMPANY STANDARDS</span></h3>
+                    <h3><span class="bold">Project or Company Standards</span></h3>
                     <!--<p>CAD/BIM Standards, Specs, and more</p>-->
                     <p>&nbsp</p>
                   </div>
                   <div>
-                    Pencil 9 can help your organization manage many standards (such as CAD/BIM standards, specifications, and templates) and provide solutions to centralize, manage, distribute and deploy those standards to any user anywhere, enabling a connected project team regardless of location.
+                    Pencil 9 can help your organization manage many standards (such as CAD/BIM standards, specifications, and templates) and provide solutions to centralize, manage, distribute and deploy those standards to any user anywhere - even outside your organization, enabling a connected project team regardless of location.
                   </div>
 								</div>
               </div>
@@ -578,7 +579,7 @@
                     <div class="fes4-box-icon">
                       <div class="icon icon-basic-info"></div>
                     </div>
-                    <h3><span class="bold">INFORMATION MANAGEMENT</span></h3>
+                    <h3><span class="bold">Information Management</span></h3>
                     <!--<p>ISO 19650, BIM</p>-->
                     <p>&nbsp</p>
                   </div>
@@ -595,7 +596,7 @@
                     <div class="fes4-box-icon">
                       <div class="icon icon-arrows-rotate"></div>
                     </div>
-                    <h3><span class="bold">AUTOMATION</span></h3>
+                    <h3><span class="bold">Automation</span></h3>
                     <!--<p>Data and Models</p>-->
                     <p>&nbsp</p>
                   </div>
@@ -673,35 +674,19 @@
             -->
               
 						<div class="row">
-            
+        
               <div class="col-xs-12 col-sm-4 col-md-4">
-                <div class="fes4-box wow fadeIn" data-wow-delay="400ms">
-								  <div class="fes4-title-cont" >
-                    <div class="circle-icon-50"></div>
-								  	<div class="fes4-box-icon">
-								  		<div class="icon icon-ecommerce-bag"></div>
-                    </div>
-                    <h3><span class="bold">Pencil 9 Software</span></h3>
-                    <p>PROJECT & ENTERPRISE</p>
-                  </div>
-                  <div>
-                    Pencil 9 software applications can be used at a project level, or scaled to an enterprise level.
-                  </div>
-								</div>
-              </div>
-              
-							<div class="col-xs-12 col-sm-4 col-md-4">
                 <div class="fes4-box wow fadeIn" data-wow-delay="200ms">
 								  <div class="fes4-title-cont" >
                     <div class="circle-icon-50"></div>
 								  	<div class="fes4-box-icon">
-                      <div class="icon icon-basic-mixer2"></div>
+                      <div class="icon icon-arrows-squares"></div>
                     </div>
-                    <h3><span class="bold">BESPOKE SOFTWARE</span></h3>
-                    <p>SCRIPTS, UTILITIES, and MORE</p>
+                    <h3><span class="bold">Free Software</span></h3>
+                    <p>Utilities & Plugins</p>
                   </div>
                   <div>
-                    Pencil 9 can develop bespoke applications and utilities to help your organization achieve its ambitions.
+                    Pencil 9 has a suite of Apps available on the <a href="https://apps.autodesk.com/All/en/List/Search?isAppSearch=True&searchboxstore=All&facet=&collection=&sort=&query=pencil+9">Autodesk Exchange</a>. These are free Apps that help make your life easier...because that's what we love to do!
                   </div>
 								</div>
               </div>
@@ -711,13 +696,30 @@
 								  <div class="fes4-title-cont" >
                     <div class="circle-icon-50"></div>
 								  	<div class="fes4-box-icon">
-                      <div class="icon icon-arrows-squares"></div>
+                      <div class="icon icon-basic-mixer2"></div>
                     </div>
-                    <h3><span class="bold">FREE SOFTWARE</span></h3>
-                    <p>UTILITIES & PLUGINS</p>
+                    <h3><span class="bold">Bespoke Software</span></h3>
+                    <p>Scripts, Utilities, and More</p>
                   </div>
                   <div>
-                    Pencil 9 has a suite of Apps available on the <a href="https://apps.autodesk.com/All/en/List/Search?isAppSearch=True&searchboxstore=All&facet=&collection=&sort=&query=pencil+9">Autodesk Exchange</a>. These are free Apps that help make your life easier...because that's what we love to do!
+                    Pencil 9 can develop bespoke applications and utilities to help your organization achieve its ambitions.
+                  </div>
+								</div>
+              </div>
+
+              <div class="col-xs-12 col-sm-4 col-md-4">
+                <div class="fes4-box wow fadeIn" data-wow-delay="400ms">
+								  <div class="fes4-title-cont" >
+                    <div class="circle-icon-50"></div>
+								  	<div class="fes4-box-icon">
+								  		<div class="icon icon-ecommerce-bag"></div>
+                    </div>
+                    <h3><span class="bold">Pencil 9 Software</span></h3>
+                    <p>Project & Enterprise</p>
+                  </div>
+                  <div>
+                    Stay tuned to learn more about commercially available Pencil 9 software applications. 
+                    <!--Pencil 9 software applications can be used at a project level, or scaled to an enterprise level.-->
                   </div>
 								</div>
               </div>
@@ -765,7 +767,7 @@
             <div class="row">
             
               <div class="col-md-7">
-                  <h3>REMOTE WORKING & GLOBAL WORKSHARING</h3>
+                  <h3>Remote Working & Global Worksharing</h3>
                   <p>Being able to work remotely and connect people from any region to your project is critical. Pencil 9 can assist in developing your remote working practice
                     to ensure your teams are connected regardless of their location.
                   </p>
@@ -795,7 +797,7 @@
             
               <div class="col-md-7">
                 <!--<blockquote class="testimonial-2">-->
-                  <h3>MANAGING PROJECT & COMPANY STANDARDS</h3>
+                  <h3>Managing Project & Company Standards</h3>
                   <p>A robust digital standards management solution keeps you more organized and improves consistency. Pencil 9 can provide solutions to manage your standards and content. Alongside our remote worksharing solution, this ensures your teams have the right standards for the project, no matter where they are located and automatically configures your design applications accordingly.</p>
                 <!--</blockquote>-->
               </div>
@@ -823,7 +825,7 @@
             <div class="row">
             
               <div class="col-md-7">
-                <h3>BENTLEY SOLUTIONS</h3>
+                <h3>Bentley Solutions</h3>
                   <p>Upgrading your Bentley Applications from V8i to CONNECT presents several challenges and opportunities. Pencil 9 can help you with your firm's migration and can assist in optimizing your Workspaces and Datasets.</p>
               </div>
 
@@ -851,7 +853,7 @@
             <div class="row">
             
               <div class="col-md-7">
-                <h3>BENTLEY PROJECTWISE SUPPORT</h3>  
+                <h3>Bentley ProjectWise Support</h3>  
                 <p>Pencil 9 can help you optimize and upgrade your Bentley ProjectWise infrastructure and environment including transitioning from on-premise to the cloud.</p>
               </div>
 
@@ -878,7 +880,7 @@
             <div class="row">
             
               <div class="col-md-7">
-                <h3>AUTODESK SOLUTIONS</h3>
+                <h3>Autodesk Solutions</h3>
                   <p>From Application Plugins to traditional profiles, Pencil 9 can help you optimize the best solution for your firm. Use this in conjunction with our ProjectWise or global worksharing solutions to deliver Autodesk projects anywhere.</p>
               </div>
 
@@ -919,7 +921,7 @@
               <div class="col-sm-6 col-md-4 col-lg-4 wow fadeInUp pb-70" >
                   
                 <div class="post-prev-title">
-                  <h3>OUR BACKGROUND</h3>
+                  <h3>Our Background</h3>
                 </div>
                   
                 <div>
@@ -932,7 +934,7 @@
               <div class="col-sm-6 col-md-4 col-lg-4 wow fadeInUp pb-70" data-wow-delay="200ms" >
                 
                 <div class="post-prev-title">
-                  <h3>OUR PASSION</h3>
+                  <h3>Our Passion</h3>
                 </div>
                   
                 <div>
@@ -945,7 +947,7 @@
               <div class="col-sm-6 col-md-4 col-lg-4 wow fadeInUp pb-70" data-wow-delay="400ms" >
                   
                 <div class="post-prev-title">
-                  <h3>OUR APPROACH</h3>
+                  <h3>Our Approach</h3>
                 </div>
                   
                 <div>


### PR DESCRIPTION
Pencil 9 and Slogan are larger on main slide. Removed capilizations from titles/sub-titles (still left some for the section titles), removed period from slogan added line about externals, re-worded Pencil 9 Software